### PR TITLE
[Task 2] SharedPreferences + DEFAULT_WLED_HOST

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,7 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "DEFAULT_WLED_HOST", "\"192.168.1.100\"")
     }
 
     buildTypes {
@@ -35,6 +36,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 

--- a/app/src/main/java/com/yoyo/mushmoodapp/MainActivity.kt
+++ b/app/src/main/java/com/yoyo/mushmoodapp/MainActivity.kt
@@ -10,12 +10,16 @@ import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import dagger.hilt.android.AndroidEntryPoint
 import com.yoyo.mushmoodapp.ui.theme.MushMoodAppTheme
+import com.yoyo.mushmoodapp.data.prefs.Prefs
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @Inject lateinit var prefs: Prefs
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Log.d("MainActivity", "onCreate")
+        Log.d("MainActivity", "onCreate - host=${prefs.getHost()}")
         enableEdgeToEdge()
         setContent {
             MushMoodAppTheme {

--- a/app/src/main/java/com/yoyo/mushmoodapp/data/prefs/Prefs.kt
+++ b/app/src/main/java/com/yoyo/mushmoodapp/data/prefs/Prefs.kt
@@ -1,0 +1,32 @@
+package com.yoyo.mushmoodapp.data.prefs
+
+import android.content.Context
+import android.util.Log
+import androidx.core.content.edit
+import com.yoyo.mushmoodapp.BuildConfig
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class Prefs @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val prefs = context.getSharedPreferences("mushmood_prefs", Context.MODE_PRIVATE)
+
+    fun getHost(): String {
+        val host = prefs.getString(KEY_HOST, BuildConfig.DEFAULT_WLED_HOST) ?: BuildConfig.DEFAULT_WLED_HOST
+        Log.d(TAG, "getHost: $host")
+        return host
+    }
+
+    fun setHost(host: String) {
+        Log.d(TAG, "setHost: $host")
+        prefs.edit { putString(KEY_HOST, host) }
+    }
+
+    private companion object {
+        private const val KEY_HOST = "host"
+        private const val TAG = "Prefs"
+    }
+}


### PR DESCRIPTION
## Summary
- add DEFAULT_WLED_HOST BuildConfig field
- introduce Prefs wrapper for host persistence with logging
- log current host on activity start

## Testing
- `./gradlew test` *(fails: SDK location not found)*

Closes #2
Part of #1

------
https://chatgpt.com/codex/tasks/task_e_68a4b2c1cf488328abe8c7cdec6cf672