### PR TITLE
[Task 4] ExoPlayer Repository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.media3.exoplayer)
+    implementation(libs.kotlinx.coroutines.android)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/yoyo/mushmoodapp/player/DefaultPlayerRepository.kt
+++ b/app/src/main/java/com/yoyo/mushmoodapp/player/DefaultPlayerRepository.kt
@@ -1,0 +1,68 @@
+package com.yoyo.mushmoodapp.player
+
+import android.content.Context
+import androidx.annotation.RawRes
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.datasource.RawResourceDataSource
+import androidx.media3.exoplayer.ExoPlayer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+class DefaultPlayerRepository(
+    private val context: Context,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+) : PlayerRepository {
+
+    private val audioAttributes = AudioAttributes.Builder()
+        .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+        .setUsage(C.USAGE_MEDIA)
+        .build()
+
+    private val player: ExoPlayer = ExoPlayer.Builder(context)
+        .setAudioAttributes(audioAttributes, true)
+        .setHandleAudioBecomingNoisy(true)
+        .build()
+
+    override fun playRaw(@RawRes resId: Int) {
+        val uri = RawResourceDataSource.buildRawResourceUri(resId)
+        val item = MediaItem.fromUri(uri)
+        player.setMediaItem(item)
+        player.prepare()
+        player.volume = 1f
+        player.playWhenReady = true
+    }
+
+    override fun stop() {
+        player.stop()
+    }
+
+    override fun fadeTo(@RawRes resId: Int, fadeOutMillis: Long, fadeInMillis: Long) {
+        scope.launch {
+            fadeVolume(from = player.volume, to = 0f, duration = fadeOutMillis)
+            val uri = RawResourceDataSource.buildRawResourceUri(resId)
+            val item = MediaItem.fromUri(uri)
+            player.setMediaItem(item)
+            player.prepare()
+            player.volume = 0f
+            player.playWhenReady = true
+            fadeVolume(from = 0f, to = 1f, duration = fadeInMillis)
+        }
+    }
+
+    private suspend fun fadeVolume(from: Float, to: Float, duration: Long) {
+        val steps = 20
+        val stepTime = duration / steps
+        val delta = (to - from) / steps
+        var current = from
+        repeat(steps) {
+            current += delta
+            player.volume = current.coerceIn(0f, 1f)
+            delay(stepTime)
+        }
+    }
+}

--- a/app/src/main/java/com/yoyo/mushmoodapp/player/PlayerRepository.kt
+++ b/app/src/main/java/com/yoyo/mushmoodapp/player/PlayerRepository.kt
@@ -1,0 +1,9 @@
+package com.yoyo.mushmoodapp.player
+
+import androidx.annotation.RawRes
+
+interface PlayerRepository {
+    fun playRaw(@RawRes resId: Int)
+    fun stop()
+    fun fadeTo(@RawRes resId: Int, fadeOutMillis: Long = 1500, fadeInMillis: Long = 600)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,8 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+exoplayer = "1.4.1"
+coroutines = "1.8.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,6 +26,8 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "exoplayer" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add ExoPlayer-based PlayerRepository with playRaw, stop, and fadeTo
- wire ExoPlayer and coroutine dependencies

## Testing
- `./gradlew assembleDebug -x lint -x test`

References: #1
Closes: #4

------
https://chatgpt.com/codex/tasks/task_e_68a4d95715d88328a6881834aef47b52