### PR TITLE
[Task 8] Compose UI – gradient, status, scene buttons

### DIFF
--- a/app/src/main/java/com/yoyo/mushmoodapp/MainActivity.kt
+++ b/app/src/main/java/com/yoyo/mushmoodapp/MainActivity.kt
@@ -1,63 +1,22 @@
 package com.yoyo.mushmoodapp
 
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import dagger.hilt.android.AndroidEntryPoint
+import com.yoyo.mushmoodapp.ui.MainScreen
 import com.yoyo.mushmoodapp.ui.theme.MushMoodAppTheme
-import com.yoyo.mushmoodapp.scenes.SceneDefs
-import com.yoyo.mushmoodapp.data.prefs.Prefs
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-    @Inject lateinit var prefs: Prefs
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Log.i(
-            "SceneDefs",
-            "Presets: default=${SceneDefs.DEFAULT_PRESET_ID}, " +
-                "A=${SceneDefs.sceneA.presetId}, " +
-                "B=${SceneDefs.sceneB.presetId}, " +
-                "C=${SceneDefs.sceneC.presetId}"
-        )
         enableEdgeToEdge()
         setContent {
             MushMoodAppTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                MainScreen()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    MushMoodAppTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/yoyo/mushmoodapp/player/DefaultPlayerRepository.kt
+++ b/app/src/main/java/com/yoyo/mushmoodapp/player/DefaultPlayerRepository.kt
@@ -7,12 +7,14 @@ import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.datasource.RawResourceDataSource
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.common.util.UnstableApi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
+@UnstableApi
 class DefaultPlayerRepository(
     private val context: Context,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)

--- a/app/src/main/java/com/yoyo/mushmoodapp/player/di/PlayerModule.kt
+++ b/app/src/main/java/com/yoyo/mushmoodapp/player/di/PlayerModule.kt
@@ -3,6 +3,7 @@ package com.yoyo.mushmoodapp.player.di
 import android.content.Context
 import com.yoyo.mushmoodapp.player.DefaultPlayerRepository
 import com.yoyo.mushmoodapp.player.PlayerRepository
+import androidx.media3.common.util.UnstableApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -16,6 +17,7 @@ object PlayerModule {
 
     @Provides
     @Singleton
+    @UnstableApi
     fun providePlayerRepository(
         @ApplicationContext context: Context
     ): PlayerRepository = DefaultPlayerRepository(context)

--- a/app/src/main/java/com/yoyo/mushmoodapp/ui/MainScreen.kt
+++ b/app/src/main/java/com/yoyo/mushmoodapp/ui/MainScreen.kt
@@ -1,0 +1,118 @@
+package com.yoyo.mushmoodapp.ui
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.yoyo.mushmoodapp.scenes.SceneDefs
+import com.yoyo.mushmoodapp.scenes.GradientSpec
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MainScreen(viewModel: MainViewModel = hiltViewModel()) {
+    val state by viewModel.uiState.collectAsState()
+
+    val gradientSpec = state.runningSceneId?.let { SceneDefs.scenes[it].gradient } ?: SceneDefs.defaultGradient
+
+    val statusText = state.runningSceneId?.let { id ->
+        val minutes = state.timeLeftSec / 60
+        val seconds = state.timeLeftSec % 60
+        "Scene ${'A' + id} — %02d:%02d".format(minutes, seconds)
+    } ?: "No active scene"
+
+    AnimatedGradientBackground(gradientSpec) {
+        Scaffold(
+            containerColor = Color.Transparent,
+            topBar = {
+                CenterAlignedTopAppBar(
+                    title = {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text("MUSHMOODAPP")
+                            Text(statusText, style = MaterialTheme.typography.bodySmall)
+                        }
+                    },
+                    colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                        containerColor = Color.Transparent
+                    )
+                )
+            }
+        ) { innerPadding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Button(
+                    onClick = { viewModel.onSceneClick(0) },
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp)
+                ) { Text("Scene A") }
+                Button(
+                    onClick = { viewModel.onSceneClick(1) },
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp)
+                ) { Text("Scene B") }
+                Button(
+                    onClick = { viewModel.onSceneClick(2) },
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp)
+                ) { Text("Scene C") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AnimatedGradientBackground(
+    spec: GradientSpec,
+    content: @Composable () -> Unit
+) {
+    val transition = rememberInfiniteTransition(label = "gradient")
+    val offset by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(spec.animationDurationMillis, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "offset"
+    )
+    val brush = Brush.linearGradient(
+        colors = spec.colors,
+        start = Offset.Zero,
+        end = Offset(offset, offset)
+    )
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(brush)
+    ) {
+        content()
+    }
+}
+


### PR DESCRIPTION
## Summary
- add animated gradient background that changes with scene
- display app title and scene status with countdown
- provide Scene A/B/C buttons wired to onSceneClick
- annotate media3 player classes with UnstableApi to satisfy lint

## Testing
- `./gradlew build`

Closes #8
Refs #1

------
https://chatgpt.com/codex/tasks/task_e_68a59f518cb48328a66dcc95a8ae8b36